### PR TITLE
Fixed typo in _miscop_get_int

### DIFF
--- a/riscos_toolbox/gadgets/__init__.py
+++ b/riscos_toolbox/gadgets/__init__.py
@@ -74,10 +74,10 @@ class Gadget:
     def _miscop_get_text(self, op):
         """Use Toolbox_ObjectMiscOp to get a string. This call will allocate
            a suitably-sized buffer, read the string and return it."""
-        buf_size = swi.swi('Toolbox_ObjectMiscOp', '0IIII00;....I',
+        buf_size = swi.swi('Toolbox_ObjectMiscOp', '0III00;.....I',
                            self.window.id,op,self.id)
-        buffer = swi.block((buf_size+3)/4)
-        swi.swi('Toolbox_ObjectMiscOp', '0IIIIbI',
+        buffer = swi.block((buf_size+3)//4)
+        swi.swi('Toolbox_ObjectMiscOp', '0IIIbi',
                            self.window.id,op,self.id,buffer,buf_size)
         return buffer.nullstring()
 

--- a/riscos_toolbox/gadgets/__init__.py
+++ b/riscos_toolbox/gadgets/__init__.py
@@ -63,7 +63,7 @@ class Gadget:
 
     def _miscop_get_int(self, op):
         """Use Toolbox_ObjectMiscOp to get an unsigned integer."""
-        return swi.swi('Toolbox_ObjectMiscOp', '0III:I',
+        return swi.swi('Toolbox_ObjectMiscOp', '0III;I',
                        self.window.id,op,self.id)
 
     def _miscop_set_text(self, op, text):


### PR DESCRIPTION
A colon was substituted for a semicolon in this argument format string, causing calls to this method to fail with "Too Few Arguments"