### PR TITLE
Fix breaking change in _miscop_get_text Fixes https://github.com/c-jo/riscos-toolbox/issues/19

### DIFF
--- a/riscos_toolbox/gadgets/__init__.py
+++ b/riscos_toolbox/gadgets/__init__.py
@@ -77,7 +77,7 @@ class Gadget:
         buf_size = swi.swi('Toolbox_ObjectMiscOp', '0III00;.....I',
                            self.window.id,op,self.id)
         buffer = swi.block((buf_size+3)//4)
-        swi.swi('Toolbox_ObjectMiscOp', '0iIIIbI',
+        swi.swi('Toolbox_ObjectMiscOp', '0iIibI',
                            self.window.id, op,self.id, buffer, buf_size)
         return buffer.nullstring()
 


### PR DESCRIPTION
The committed fix for issue #9 d685972 broke _miscop_get_text by adding an extra integer argument to the format string; this affects all gadgets with text attributes. This was also merged into main. This commit removes the extra argument and also flips the component ID arg to a signed int.

This fix was tested with https://github.com/laurenrad/TBPTest on the ActionButton gadget.