### PR TITLE
Fix ScrollList make_visible method.

### DIFF
--- a/riscos_toolbox/gadgets/scrolllist.py
+++ b/riscos_toolbox/gadgets/scrolllist.py
@@ -30,7 +30,7 @@ class ScrollList(Gadget):
                         self.window.id, 16416, self.id, offset)
 
     def make_visible(self, index):
-        swi.swi('Toolbox_ObjectMiscOp','0III',
+        swi.swi('Toolbox_ObjectMiscOp','0iIii',
                 self.window.id, 16417, self.id, index)
 
     @property


### PR DESCRIPTION
Fixes ScrollList's make_visible method by adding an int to the format string in its call to Toolbox_ObjectMiscOp. Fixes #27, see issue for more details. Additionally, the format string items for the ComponentId and ObjectId have been changed from unsigned to signed.