### PR TITLE
Fix setting font on Button gadget

### DIFF
--- a/riscos_toolbox/gadgets/button.py
+++ b/riscos_toolbox/gadgets/button.py
@@ -42,18 +42,11 @@ class Button(Gadget):
     @validation.setter
     def validation(self, validation):
         return self._miscop_set_text(Button.SetValidation, validation)
-
-    @property
-    def font(self):
-        return swi.swi('Toolbox_ObjectMiscOp','0III',
-            self.window.id, Button.GetFont)
-
-    @font.setter
-    def fond(self, font):
-        font, width, height = font
-        swi.swi('Toolbox_ObjectMiscOp','0IIIsII',
-            self.window.id, Button.SetFont,
-            self.id, font, int(width*16), int(height*16))
+    
+    def set_font(self, font, width, height):
+        swi.swi('Toolbox_ObjectMiscOp','0iIisii',
+                self.window.id, Button.SetFont,
+                self.id, font, int(width*16), int(height*16))
 
 class ButtonDefinition(GadgetDefinition):
     _fields_ = [

--- a/riscos_toolbox/gadgets/button.py
+++ b/riscos_toolbox/gadgets/button.py
@@ -15,7 +15,6 @@ class Button(Gadget):
     SetValidation  = _type + 4
     GetValidation  = _type + 5
     SetFont        = _type + 6
-    GetFont        = _type + 7
 
     @property
     def icon_flags(self):


### PR DESCRIPTION
Fixes #26 - see issue for details. This removes the Button class's font property and replaces it with a set_font method, as the setter was broken and there is no getter method in the Toolbox for this gadget. This does therefore involve a design change but shouldn't break anything as neither the setter nor getter were working previously.