### PR TITLE
Fixes for flake8 reported whitespace problems.

### DIFF
--- a/Hyper/utils.py
+++ b/Hyper/utils.py
@@ -19,17 +19,17 @@ def file_load(filename):
             size = header[1]
             buffer = (ctypes.c_byte * size)()
 
-            ws_size = swi.swi("Squash_Decompress", "II;I", 8, sq_size-20)
+            ws_size = swi.swi("Squash_Decompress", "II;I", 8, sq_size - 20)
             workspace = (ctypes.c_byte * ws_size)()
 
             swi.swi("Squash_Decompress", "iIIIII", 4,
                     ctypes.addressof(workspace),
-                    ctypes.addressof(squashed)+20,
-                    sq_size-20,
+                    ctypes.addressof(squashed) + 20,
+                    sq_size - 20,
                     ctypes.addressof(buffer), size)
 
     return buffer, size
 
-  
+
 if __name__ == "__main__":
     print(file_load("underlay"))

--- a/flake8.sh
+++ b/flake8.sh
@@ -1,1 +1,2 @@
-python3 -m flake8 . --count --ignore=E221,E501 --show-source --statistics
+#!/bin/bash
+python3 -m flake8 . --count --ignore=E221,E501,E227 --show-source --statistics

--- a/riscos_toolbox/__init__.py
+++ b/riscos_toolbox/__init__.py
@@ -108,8 +108,8 @@ def run(application):
     global _quit
 
     while not _quit:
-        reason,sender = swi.swi(
-            'Wimp_Poll','II;I.I',
+        reason, sender = swi.swi(
+            'Wimp_Poll', 'II;I.I',
             application.poll_flags,
             ctypes.addressof(poll_buffer))
 

--- a/riscos_toolbox/_types.py
+++ b/riscos_toolbox/_types.py
@@ -25,7 +25,7 @@ class IDBlock(ctypes.Structure):
     ]
 
     def __repr__(self):
-        return "Acestor: {} Parent: {} Self: {}".format(self.ancestor, self.parent, self.self)
+        return "Ancestor: {} Parent: {} Self: {}".format(self.ancestor, self.parent, self.self)
 
 
 class Point(ctypes.Structure):

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 python -m unittest discover -s test

--- a/test/components/test_saveas.py
+++ b/test/components/test_saveas.py
@@ -10,10 +10,12 @@ import riscos_toolbox.objects.saveas
 
 import swi
 
+
 TEST_OBJECT_ID = 0x1001
 TEST_WINDOW_ID = 0x2001
 TEST_TITLE     = "Test Title"
 TEST_NAME      = "Test"
+
 
 class SwiMock:
     def __init__(self):
@@ -37,7 +39,7 @@ class SwiMock:
             return True
 
         if not argmatch(exp, args):
-            raise RuntimeError("SWI call mismatch: got {} exp {}".format(args, exp)) 
+            raise RuntimeError("SWI call mismatch: got {} exp {}".format(args, exp))
 
         self._pos += 1
         return ret
@@ -50,6 +52,7 @@ class SwiMock:
     def completed(self):
         return self._pos == len(self._expect)
 
+
 class MockBlockString:
     def __init__(self, string):
         self.string = string
@@ -60,12 +63,15 @@ class MockBlockString:
     def nullstring(self):
         return self.string
 
+
 def expect_miscop(obj, op, ret):
     return (('Toolbox_ObjectMiscOp', 'III;I', 0, obj, op), ret)
+
 
 def expect_miscop_string(swimock, obj, op, str):
     swimock.expect(('Toolbox_ObjectMiscOp', 'III00;....I', 0, obj, op), len(str))
     swimock.expect(('Toolbox_ObjectMiscOp', 'IIIbI', 0, obj, op, None, len(str)), None)
+
 
 class SaveAs(unittest.TestCase):
 

--- a/test/events/test_redraw_window.py
+++ b/test/events/test_redraw_window.py
@@ -3,15 +3,16 @@ import riscos_toolbox.wimp_events.redraw_window as redraw_window
 import unittest
 import struct
 
+
 class RedrawWindow(unittest.TestCase):
 
     def test_from_init(self):
         rw = redraw_window.RedrawWindow()
-        assert(rw.event_id == 1)
+        assert (rw.event_id == 1)
 
     def test_from_block(self):
         rw = redraw_window.RedrawWindow.from_poll_block(
             struct.pack("i", 42)
         )
-        assert(rw.event_id == 1)
-        assert(rw.window_handle == 42)
+        assert (rw.event_id == 1)
+        assert (rw.window_handle == 42)

--- a/test/fakeswi.py
+++ b/test/fakeswi.py
@@ -3,15 +3,19 @@
 def swi(*args):
     pass
 
+
 class block:
     def __init__(self, *args):
         pass
+
+
 import unittest
 
 import fakeswi
 import sys
 
 sys.modules['swi'] = fakeswi
+
 """
 import riscos_toolbox as toolbox
 import riscos_toolbox.objects.saveas
@@ -92,4 +96,3 @@ class SaveAs(unittest.TestCase):
         self.assertEqual(saveas.title, "Test Title")
         self.assertTrue(swimock.completed)
 """
-

--- a/test/test_dispatcher.py
+++ b/test/test_dispatcher.py
@@ -14,6 +14,7 @@ id_block.ancestor.component = 0xc0003
 
 calls = []
 
+
 class TestClass01(toolbox.Object):
     def __init__(self, id):
         super().__init__(id, "test")
@@ -21,6 +22,7 @@ class TestClass01(toolbox.Object):
     @toolbox_handler(0xc101)
     def event_c101(self, event, id_block, poll_block):
         calls.append((self.__class__.__name__, self.id, event, id_block, poll_block))
+
 
 class TestClass02(toolbox.Object):
     def __init__(self, id):
@@ -33,6 +35,7 @@ class TestClass02(toolbox.Object):
     def event_c102(self, event, id_block, poll_block):
         calls.append((self.__class__.__name__, self.id, event, id_block, poll_block))
 
+
 class TestClass03(toolbox.Object):
     def __init__(self, id):
         super().__init__(id, "test")
@@ -41,9 +44,11 @@ class TestClass03(toolbox.Object):
     def event_c103(self, event, id_block, poll_block):
         calls.append((self.__class__.__name__, self.id, event, id_block, poll_block))
 
+
 @toolbox_handler(0xff01)
 def test_func(event, id_block, *args):
     calls.append((test_func.__name__, None, event, id_block, args))
+
 
 class ObjectDispatchTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_toolbox.py
+++ b/test/test_toolbox.py
@@ -6,7 +6,7 @@ sys.modules['swi'] = fakeswi
 
 import riscos_toolbox as toolbox
 
+
 class ToolboxTest(unittest.TestCase):
     def test_one(self):
         self.assertEqual(0, 0)
-

--- a/toolbox_types.py
+++ b/toolbox_types.py
@@ -2,6 +2,7 @@
 Python constants.
 """
 
+
 class ActionbuttonConstants(object):
 
     # .Bits
@@ -22,7 +23,6 @@ class ActionbuttonConstants(object):
     Class_ActionButton = 128
 
 
-
 class AdjusterConstants(object):
 
     # .Bits
@@ -36,7 +36,6 @@ class AdjusterConstants(object):
     Class_Adjuster = 768
 
 
-
 class ButtonConstants(object):
 
     # .Bits
@@ -45,7 +44,6 @@ class ButtonConstants(object):
 
     # Toolbox_Class
     Class_Button = 960
-
 
 
 class ColourdboxConstants(object):
@@ -77,7 +75,6 @@ class ColourdboxConstants(object):
     Class_ColourDbox = 534976
 
 
-
 class ColourmenuConstants(object):
 
     # .Bits
@@ -104,7 +101,6 @@ class ColourmenuConstants(object):
     Class_ColourMenu = 534912
 
 
-
 class DcsConstants(object):
 
     # .Bits
@@ -128,7 +124,6 @@ class DcsConstants(object):
 
     # Toolbox_Class
     Class_DCS = 535168
-
 
 
 class DdeutilsConstants(object):
@@ -157,7 +152,6 @@ class DdeutilsConstants(object):
     DDEUtils_ThrowbackProcessing = 0
 
 
-
 class DisplayfieldConstants(object):
 
     # Gadget_Flags
@@ -166,7 +160,6 @@ class DisplayfieldConstants(object):
 
     # Toolbox_Class
     Class_DisplayField = 448
-
 
 
 class DraganobjectConstants(object):
@@ -188,7 +181,6 @@ class DraganobjectConstants(object):
     DragAnObject_NoDither = (1<<8)
     DragAnObject_CallFunction = (1<<16)
     DragAnObject_FunctionSVC = (1<<17)
-
 
 
 class DraggableConstants(object):
@@ -218,7 +210,6 @@ class DraggableConstants(object):
 
     # Toolbox_Class
     Class_Draggable = 640
-
 
 
 class FileinfoConstants(object):
@@ -251,7 +242,6 @@ class FileinfoConstants(object):
 
     # Toolbox_Class
     Class_FileInfo = 535232
-
 
 
 class FontdboxConstants(object):
@@ -302,7 +292,6 @@ class FontdboxConstants(object):
     Class_FontDbox = 535040
 
 
-
 class FontmenuConstants(object):
 
     # .Bits
@@ -323,7 +312,6 @@ class FontmenuConstants(object):
 
     # Toolbox_Class
     Class_FontMenu = 535104
-
 
 
 class FrontendConstants(object):
@@ -364,7 +352,6 @@ class GadgetConstants(object):
     Gadget_Faded = (1<<31)
 
 
-
 class IconbarConstants(object):
 
     # .Bits
@@ -401,12 +388,10 @@ class IconbarConstants(object):
     Class_Iconbar = 534784
 
 
-
 class KeyboardshortcutConstants(object):
 
     # KeyboardShortcut_Flags
     KeyboardShortcut_ShowAsMenu = (1<<0)
-
 
 
 class LabelConstants(object):
@@ -420,7 +405,6 @@ class LabelConstants(object):
     Class_Label = 320
 
 
-
 class LabelledboxConstants(object):
 
     # Gadget_Flags
@@ -429,7 +413,6 @@ class LabelledboxConstants(object):
 
     # Toolbox_Class
     Class_LabelledBox = 256
-
 
 
 class MenuConstants(object):
@@ -480,7 +463,6 @@ class MenuConstants(object):
     Class_Menu = 534720
 
 
-
 class NumberrangeConstants(object):
 
     # .Bits
@@ -516,7 +498,6 @@ class NumberrangeConstants(object):
     Class_NumberRange = 832
 
 
-
 class OptionbuttonConstants(object):
 
     # .Bits
@@ -526,7 +507,6 @@ class OptionbuttonConstants(object):
 
     # Toolbox_Class
     Class_OptionButton = 192
-
 
 
 class PopupConstants(object):
@@ -539,7 +519,6 @@ class PopupConstants(object):
 
     # Toolbox_Class
     PopUp_Class = 704
-
 
 
 class PrintdboxConstants(object):
@@ -595,7 +574,6 @@ class PrintdboxConstants(object):
     PrintDbox_Percent = 137035792
 
 
-
 class ProginfoConstants(object):
 
     # .Bits
@@ -637,7 +615,6 @@ class ProginfoConstants(object):
     Class_ProgInfo = 535360
 
 
-
 class QuitConstants(object):
 
     # .Bits
@@ -659,7 +636,6 @@ class QuitConstants(object):
     Class_Quit = 535184
 
 
-
 class RadiobuttonConstants(object):
 
     # .Bits
@@ -674,7 +650,6 @@ class RadiobuttonConstants(object):
 
     # Toolbox_Class
     Class_RadioButton = 384
-
 
 
 class SaveasConstants(object):
@@ -720,7 +695,6 @@ class SaveasConstants(object):
     Class_SaveAs = 535488
 
 
-
 class ScaleConstants(object):
 
     # .Bits
@@ -758,7 +732,6 @@ class ScaleConstants(object):
     Class_Scale = 535552
 
 
-
 class SliderConstants(object):
 
     # .Bits
@@ -789,7 +762,6 @@ class SliderConstants(object):
     Class_Slider = 576
 
 
-
 class StringsetConstants(object):
 
     # .Bits
@@ -815,7 +787,6 @@ class StringsetConstants(object):
 
     # Toolbox_Class
     StringSet_Class = 896
-
 
 
 class ToolboxConstants(object):
@@ -893,7 +864,6 @@ class ToolboxConstants(object):
     Toolbox_ShowAsSubMenu = (1<<1)
 
 
-
 class WindowConstants(object):
 
     # .Bits
@@ -938,7 +908,6 @@ class WindowConstants(object):
     Window_ToolBarETL = (1<<3)
 
 
-
 class WindowsupportexternalConstants(object):
 
     # .Int
@@ -951,7 +920,6 @@ class WindowsupportexternalConstants(object):
     WindowSupportExternal_HandlerPostAdd = 12
     WindowSupportExternal_HandlerRemove = 2
     WindowSupportExternal_HandlerSetFocus = 10
-
 
 
 class WritablefieldConstants(object):
@@ -967,6 +935,3 @@ class WritablefieldConstants(object):
 
     # Toolbox_Class
     Class_WritableField = 512
-
-
-


### PR DESCRIPTION
Most of the whitespace problems are fixed by this change, just removing or adding lines or spaces around statements.

*Statistics before:*

```
3     E226 missing whitespace around arithmetic operator
2     E231 missing whitespace after ','
3     E275 missing whitespace after keyword
14    E302 expected 2 blank lines, found 1
33    E303 too many blank lines (3)
1     E305 expected 2 blank lines after class or function definition, found 0
7     E402 module level import not at top of file
8     F401 '.base.get_object' imported but unused
2     F403 'from ._types import *' used; unable to detect undefined names
6     F405 'IDBlock' may be undefined, or defined from star imports: ._types, .events
1     F811 redefinition of unused '__init__' from line 26
2     W291 trailing whitespace
1     W293 blank line contains whitespace
3     W391 blank line at end of file
86
```

*Statistics after:*

```
2     E231 missing whitespace after ','
7     E402 module level import not at top of file
8     F401 '.base.get_object' imported but unused
2     F403 'from ._types import *' used; unable to detect undefined names
6     F405 'IDBlock' may be undefined, or defined from star imports: ._types, .events
1     F811 redefinition of unused '__init__' from line 28
1     W291 trailing whitespace
27
```