### PR TITLE
Fix for typos in comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Library to use the RISC OS Toolbox in Python.
 
-Hyper contains a python port of the Hyper toolox demo application.
+Hyper contains a python port of the Hyper Toolbox demo application.
 
 Written by Chris Johns, with contributions from Charles Ferguson and Lauren Croney

--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -14,7 +14,7 @@ from . import BBox, Point
 # To handle a toolbox event, the @toolbox_handler decorator is used on a member of
 # a class derived from riscos_toolbox.  event.EvebtDispatcher, such as .Object
 # or .Application. The decorator can be used to match all components (with
-# @ToolboxEvebt(event)...), one component (@toolbxo_handler(event, component)...)
+# @ToolboxEvent(event)...), one component (@toolbox_handler(event, component)...)
 # or a list of components (@toolbox_handler(event, [comp1,comp2]...)
 #
 # 'event' can either be a class name derived from Event, or an integer number. In
@@ -22,7 +22,7 @@ from . import BBox, Point
 # using it's from_block method. In the second, the handler will be called with the
 # raw data from the wimp poll block.
 #
-# When a toolbox event is recieved, the library will try each of the self,
+# When a toolbox event is received, the library will try each of the self,
 # parent and ancestor objects, followed by the application object, to see if
 # it has a suitable handler.
 #

--- a/riscos_toolbox/gadgets/__init__.py
+++ b/riscos_toolbox/gadgets/__init__.py
@@ -98,7 +98,7 @@ class Gadget(Component):
 
     def _miscop_set_font(self, op, name, width=None, height=None, size=None):
         """Use Toolbox_ObjectMiscOp to set a font. Specify the font name and
-           height and width or size (in points). Specifing height, with and size
+           height and width or size (in points). Specifying height, with and size
            will result in size value being ignored. If font name is None, the
            system font will be used."""
         if width is None and height is None and size:

--- a/riscos_toolbox/gadgets/textarea.py
+++ b/riscos_toolbox/gadgets/textarea.py
@@ -47,7 +47,7 @@ class TextArea(Gadget):
     def text(self, text):
         self._miscop_set_string(TextArea.SetText, text)
 
-    # GetSelection and SetSelection work siimilarly to StringSet's, but the flags are
+    # GetSelection and SetSelection work in a similar way to StringSet's, but the flags are
     # backwards, meaning bit 0 set is return string and bit 0 clear is return text.
     # These two usages have been split into two properties, selection_points for the indices
     # and selection for the text itself.
@@ -66,7 +66,7 @@ class TextArea(Gadget):
                 self.id, start, end)
 
     # No matter what, this seems to return 1 character past where it should;
-    # This was tested with the C veneer and had the same behavior, so it appears
+    # This was tested with the C veneer and had the same behaviour, so it appears
     # to be a quirk or bug with the Toolbox itself. Otherwise, it is harmless as
     # selecting the whole text causes no problems.
     @property

--- a/riscos_toolbox/mixins/printing.py
+++ b/riscos_toolbox/mixins/printing.py
@@ -27,7 +27,7 @@ class PrintMixin:
     def give_rectangles(self, page, sideways, scale):
         """
         Gets the rectangles needed to draw the given page. If sideways is True
-        it should be drawn sidewase, otherwise upright.
+        it should be drawn sideways, otherwise upright.
 
         Returns a list of
         ( id (unsigned int),


### PR DESCRIPTION
There were a few typos in comments; these have been corrected.

The README has been moved to be markdown, as that appears to be what it was intended to be anyhow.