### PR TITLE
Fix for the initialisation of untemplated object.

### DIFF
--- a/riscos_toolbox/base.py
+++ b/riscos_toolbox/base.py
@@ -89,7 +89,7 @@ class Object(EventHandler):
         if id in _objects:
             obj = _objects[id]
         else:
-            obj = Object(id)
+            obj = Object(id, None)
         if comp_id == 0xffffffff:
             comp = None
         else:


### PR DESCRIPTION
Untemplated objects can be managed through the Toolbox library, but their construction when referenced would error because the `template` argument wasn't passed. It is now passed as None.