### PR TITLE
Set of minor bugfixes to make riscos-toolbox work with !TBPTest 

### DIFF
--- a/riscos_toolbox/application.py
+++ b/riscos_toolbox/application.py
@@ -34,7 +34,7 @@ class Application(EventHandler):
         if poll_flags is not None:
             self.poll_flags = poll_flags
         else:
-            self.poll_flags = _make_poll_flags(registered_wimp_events)
+            self.poll_flags = _make_poll_flags(registered_wimp_events())
         initialise(appdir)
 
     def set_poll_flag(self, flag):

--- a/riscos_toolbox/application.py
+++ b/riscos_toolbox/application.py
@@ -1,5 +1,5 @@
 from .events import EventHandler, registered_wimp_events
-from _consts import Wimp
+from ._consts import Wimp
 from . import initialise, run
 
 

--- a/riscos_toolbox/gadgets/__init__.py
+++ b/riscos_toolbox/gadgets/__init__.py
@@ -24,7 +24,7 @@ class Gadget(Component):
             _gadgets[cls._type] = cls
 
     def __init__(self, window, id):
-        super().__init(id)
+        super().__init__(id)
         self.window = window
         self.id = id
         window.components[id] = self

--- a/riscos_toolbox/gadgets/draggable.py
+++ b/riscos_toolbox/gadgets/draggable.py
@@ -69,14 +69,14 @@ class DraggableDragStartedEvent(ToolboxEvent):
     event_id = Draggable.DragStarted
 
 
-class _Wimp(ctypes.Struct):
+class _Wimp(ctypes.Structure):
     _fields_ = [
         ('window_handle', ctypes.c_int32),
         ('icon_handle', ctypes.c_int32),
     ]
 
 
-class _Toolbox(ctypes.Struct):
+class _Toolbox(ctypes.Structure):
     _fields_ = [
         ('window_id', ctypes.c_uint32),
         ('component_id', ctypes.c_uint32),


### PR DESCRIPTION
FIXES #45 FIXES #46 FIXES #47 FIXES #48

I pulled down the latest from main to add some things to my !TBPTest app but found that there were a couple issues preventing it from running: 
[ Broken import in application.py #45 ](https://github.com/c-jo/riscos-toolbox/issues/45)
[ In draggable.py, ctypes.Struct should be ctypes.Structure #46 ](https://github.com/c-jo/riscos-toolbox/issues/46)
[ An error occurs when trying to set poll flags from registered wimp events #47 ](https://github.com/c-jo/riscos-toolbox/issues/47)
[ Typo in Gadget constructor #48 ](https://github.com/c-jo/riscos-toolbox/issues/48)

This is a small bundle of fixes for these, after which !TBPTest initialises correctly. (Sorry I missed PR review on these)