### PR TITLE
Remove some calls to now-nonexistent method from gadget methods

### DIFF
--- a/riscos_toolbox/gadgets/draggable.py
+++ b/riscos_toolbox/gadgets/draggable.py
@@ -48,11 +48,11 @@ class Draggable(Gadget):
 
     @property
     def state(self):
-        return self._miscop_get_int(self.GetState) != 0
+        return self._miscop_get_signed(self.GetState) != 0
 
     @state.setter
     def state(self, state):
-        return self._miscop_set_int(Draggable.SetState, 1 if state else 0)
+        return self._miscop_set_signed(Draggable.SetState, 1 if state else 0)
 
 
 class DraggableDefinition(GadgetDefinition):

--- a/riscos_toolbox/gadgets/optionbutton.py
+++ b/riscos_toolbox/gadgets/optionbutton.py
@@ -34,19 +34,19 @@ class OptionButton(Gadget):
 
     @property
     def event(self):
-        return self._miscop_get_int(OptionButton.GetEvent)
+        return self._miscop_get_signed(OptionButton.GetEvent)
 
     @event.setter
     def event(self, event):
-        return self._miscop_set_int(OptionButton.SetEvent, event)
+        return self._miscop_set_signed(OptionButton.SetEvent, event)
 
     @property
     def state(self):
-        return self._miscop_get_int(OptionButton.GetState) != 0
+        return self._miscop_get_signed(OptionButton.GetState) != 0
 
     @state.setter
     def state(self, state):
-        return self._miscop_set_int(OptionButton.SetState, 1 if state else 0)
+        return self._miscop_set_signed(OptionButton.SetState, 1 if state else 0)
 
 
 class OptionButtonDefinition(GadgetDefinition):

--- a/riscos_toolbox/gadgets/radiobutton.py
+++ b/riscos_toolbox/gadgets/radiobutton.py
@@ -44,11 +44,11 @@ class RadioButton(Gadget):
 
     @property
     def state(self):
-        return self._miscop_get_int(RadioButton.GetState) != 0
+        return self._miscop_get_signed(RadioButton.GetState) != 0
 
     @state.setter
     def state(self, state):
-        self._miscop_set_int(RadioButton.SetState, 1 if state else 0)
+        self._miscop_set_signed(RadioButton.SetState, 1 if state else 0)
 
     # Methods
     def set_font(self, *args, **kwargs):

--- a/riscos_toolbox/gadgets/slider.py
+++ b/riscos_toolbox/gadgets/slider.py
@@ -38,11 +38,11 @@ class Slider(Gadget):
 
     @property
     def value(self):
-        return self._miscop_get_int(Slider.GetValue)
+        return self._miscop_get_signed(Slider.GetValue)
 
     @value.setter
     def value(self, value):
-        self._miscop_set_int(Slider.SetValue, value)
+        self._miscop_set_signed(Slider.SetValue, value)
 
     # Bounds have been split into separate properties - this seemed the most logical way
     @property

--- a/riscos_toolbox/gadgets/textarea.py
+++ b/riscos_toolbox/gadgets/textarea.py
@@ -33,11 +33,11 @@ class TextArea(Gadget):
 
     @property
     def state(self):
-        return self._miscop_get_int(TextArea.GetState)
+        return self._miscop_get_unsigned(TextArea.GetState)
 
     @state.setter
     def state(self, state):
-        self._miscop_set_int(TextArea.SetState, state)
+        self._miscop_set_unsigned(TextArea.SetState, state)
 
     @property
     def text(self):
@@ -91,7 +91,7 @@ class TextArea(Gadget):
 
     @cursor.setter
     def cursor(self, pos):
-        self._miscop_set_int(TextArea.SetCursorPosition, pos)
+        self._miscop_set_unsigned(TextArea.SetCursorPosition, pos)
 
     # This returns a tuple containing (foreground, background)
     @property


### PR DESCRIPTION
Some gadget methods were still calling the parent class's _miscop_get_int and _miscop_set_int methods, which have been replaced with signed and unsigned versions. Fixes #50 