### PR TITLE
Bugfix bundle: update method names, fix typos

### DIFF
--- a/riscos_toolbox/gadgets/displayfield.py
+++ b/riscos_toolbox/gadgets/displayfield.py
@@ -15,7 +15,7 @@ class DisplayField(Gadget):
     # Properties
     @property
     def value(self):
-        return self._miscop_get_text(DisplayField.GetValue)
+        return self._miscop_get_string(DisplayField.GetValue)
 
     @value.setter
     def value(self, value):

--- a/riscos_toolbox/gadgets/draggable.py
+++ b/riscos_toolbox/gadgets/draggable.py
@@ -93,7 +93,7 @@ class _Target(ctypes.Union):
 class DraggableDragEndedEvent(ToolboxEvent):
 
     event_id = Draggable.DragEnded
-    _anonyumous_ = ('_target',)
+    _anonymous_ = ('_target',)
     _fields_ = [
         ('_target', _Target),
         ('_x', ctypes.c_int32),
@@ -109,7 +109,7 @@ class DraggableDragEndedEvent(ToolboxEvent):
         return self.wimp.icon_handle
 
     @property
-    def winddow_id(self):
+    def window_id(self):
         return self.toolbox.window_id
 
     @property

--- a/riscos_toolbox/gadgets/stringset.py
+++ b/riscos_toolbox/gadgets/stringset.py
@@ -39,7 +39,7 @@ class StringSet(Gadget):
     @property
     def selected(self):
         # Thankfully flags=0 means return string, so _miscop_get_text works
-        return self._miscop_get_text(StringSet.GetSelected)
+        return self._miscop_get_string(StringSet.GetSelected)
 
     @selected.setter
     def selected(self, selection):

--- a/riscos_toolbox/gadgets/textarea.py
+++ b/riscos_toolbox/gadgets/textarea.py
@@ -41,7 +41,7 @@ class TextArea(Gadget):
 
     @property
     def text(self):
-        return self._miscop_get_text(TextArea.GetText)
+        return self._miscop_get_string(TextArea.GetText)
 
     @text.setter
     def text(self, text):


### PR DESCRIPTION
Fixes #52  - updates some calls in some gadget methods to reflect a name change of one of the gadget miscop methods.