### PR TITLE
Assign _application.

### DIFF
--- a/riscos_toolbox/application.py
+++ b/riscos_toolbox/application.py
@@ -31,6 +31,7 @@ class Application(EventHandler):
         super().__init__()
         self.throwback = throwback
         global _application
+        _application = self
         if poll_flags is not None:
             self.poll_flags = poll_flags
         else:


### PR DESCRIPTION
The _application variable was never assigned. It looked like it was intended to be but had been missed.