### PR TITLE
Fix for BBox.zero() not being a static method.

### DIFF
--- a/riscos_toolbox/_types.py
+++ b/riscos_toolbox/_types.py
@@ -51,5 +51,6 @@ class BBox(ctypes.Structure):
         return "[{},{} - {},{}]". \
             format(self.min.x, self.min.y, self.max.x, self.max.y)
 
+    @staticmethod
     def zero():
         return BBox(0, 0, 0, 0)


### PR DESCRIPTION
The `zero` method should have been marked as a static method. This change just makes that method a static method.