### PR TITLE
Fix #70 and #71 - ProgInfo licence property issues.

### DIFF
--- a/riscos_toolbox/objects/proginfo.py
+++ b/riscos_toolbox/objects/proginfo.py
@@ -26,8 +26,8 @@ class ProgInfo(Object):
 
     LicenceType = IntEnum(
         "LicenceType",
-        "PublicDomain SingleUser SingleMachine Site Network Authority".split(),
-        start=0)
+        "Unset PublicDomain SingleUser SingleMachine Site Network Authority".split(),
+        start=-1)
 
     @property
     def window_id(self):
@@ -43,10 +43,10 @@ class ProgInfo(Object):
 
     @property
     def licence_type(self):
-        return ProgInfo.LicenceType(self._miscop_get_unsigned(ProgInfo.GetLicenceType))
+        return ProgInfo.LicenceType(self._miscop_get_signed(ProgInfo.GetLicenceType))
 
     @licence_type.setter
-    def license_type(self, licence_type):
+    def licence_type(self, licence_type):
         self._miscop_set_signed(ProgInfo.SetLicenceType, licence_type)
 
     @property


### PR DESCRIPTION
This corrects bugs #70 and #71 by using a signed value when getting licence_type and correcting the spelling of the setter for this property.
This also adds a -1=Unset type for the LicenceType enum as this is a valid value that the Toolbox will give back when the licence type is unset, which is default in ResEd.