### PR TITLE
Small typo of `caret` in constants.

### DIFF
--- a/riscos_toolbox/_consts.py
+++ b/riscos_toolbox/_consts.py
@@ -14,7 +14,7 @@ class Wimp:
     MenuSelection = 9
     ScrollRequest = 10
     LoseCaret = 11
-    GainCartet = 12
+    GainCaret = 12
     PollwordNonZero = 13
     UserMessage = 17
     UserMessageRecorded = 18

--- a/riscos_toolbox/application.py
+++ b/riscos_toolbox/application.py
@@ -11,7 +11,7 @@ wimp_event_masks = {
     Wimp.MouseClick: Wimp.Poll.MouseClickMask,
     Wimp.KeyPressed: Wimp.Poll.KeyPressedMask,
     Wimp.LoseCaret: Wimp.Poll.LoseCaretMask,
-    Wimp.GainCartet: Wimp.Poll.GainCaretMask,
+    Wimp.GainCaret: Wimp.Poll.GainCaretMask,
     Wimp.PollwordNonZero: Wimp.Poll.PollWordNonZeroMask,
 }
 


### PR DESCRIPTION
Caret had been typo'd.