### PR TITLE
Message IDs via subclasses

### DIFF
--- a/riscos_toolbox/_consts.py
+++ b/riscos_toolbox/_consts.py
@@ -47,3 +47,8 @@ class Toolbox:
 
 class Messages:
     Quit = 0
+
+    def __init_subclass__(subclass):
+        for k in filter(lambda k: not k.startswith('_'),
+                        subclass.__dict__.keys()):
+            setattr(Messages, k, subclass.__dict__[k])

--- a/riscos_toolbox/objects/fontdbox.py
+++ b/riscos_toolbox/objects/fontdbox.py
@@ -22,7 +22,7 @@ class FontDbox(Object):
     AboutToBeShown    = class_id + 0
     DialogueCompleted = class_id + 1
     ApplyFont         = class_id + 2
-    
+
     # Constants
     SetSize_Height = 1
     SetSize_Aspect = 2
@@ -77,6 +77,7 @@ class FontDbox(Object):
 # FontDbox Events
 class FontDboxAboutToBeShownEvent(AboutToBeShownEvent):
     event_id = FontDbox.AboutToBeShown
+
 
 class FontDboxApplyFontEvent(ToolboxEvent):
     event_id = FontDbox.ApplyFont

--- a/riscos_toolbox/objects/printdbox.py
+++ b/riscos_toolbox/objects/printdbox.py
@@ -70,7 +70,8 @@ class PrintDbox(Object):
 
     @property
     def orientation(self):
-        return Orientation.Upright if self._miscop_get_unsigned(PrintDbox.GetOrientation) == 0 else Orientation.Sideways
+        orientation = self._miscop_get_unsigned(PrintDbox.GetOrientation)
+        return Orientation.Upright if orientation == 0 else Orientation.Sideways
 
     @orientation.setter
     def orientation(self, orientation):

--- a/riscos_toolbox/user_messages/data_transfer.py
+++ b/riscos_toolbox/user_messages/data_transfer.py
@@ -1,10 +1,11 @@
+from .._consts import Messages
 from ..events import UserMessage
 from .. import Point
 
 import ctypes
 
 
-class Messages:
+class DataTransferMessages(Messages):
     DataSave = 1
     DataSaveAck = 2
     DataLoad = 3


### PR DESCRIPTION
Use subclasses of Messages to add attributes for the messages within the subclasses.
