### PR TITLE
Fix #91 - typo in ActionButtonSelectedEvent

### DIFF
--- a/riscos_toolbox/gadgets/actionbutton.py
+++ b/riscos_toolbox/gadgets/actionbutton.py
@@ -75,7 +75,7 @@ class ActionButtonSelectedEvent(ToolboxEvent):
 
     @property
     def default(self):
-        return self.flags & ActionButtonSelectedEvent.Defaut
+        return self.flags & ActionButtonSelectedEvent.Default
 
     @property
     def cancel(self):


### PR DESCRIPTION
Fixes the typo causing issue #91 