### PR TITLE
Fix #89 and #90 - delete_object fixes

### DIFF
--- a/riscos_toolbox/__init__.py
+++ b/riscos_toolbox/__init__.py
@@ -9,7 +9,8 @@ import struct
 # These methods and functions are imported for legacy purposes.
 from ._types import *  # noqa
 from ._consts import *  # noqa
-from .base import Object, _objects, get_object, create_object, find_objects, _application  # noqa
+from .base import Object, _objects, get_object, create_object, delete_object, \
+                  find_objects, _application  # noqa
 from .events import *  # noqa
 
 

--- a/riscos_toolbox/base.py
+++ b/riscos_toolbox/base.py
@@ -31,9 +31,12 @@ def create_object(template, klass=None, args=None):
 
 
 def delete_object(object, recursive=True):
-    swi.swi('Toolbox_DeleteObject', 'Ii', 1 if recursive else 0, object.id)
-    if object.id in _objects:
-        del _objects[id]
+    if isinstance(object, Object):
+        object = object.id # Take either an Object or its ID as an argument
+        
+    swi.swi('Toolbox_DeleteObject', 'Ii', 1 if recursive else 0, object)
+    if object in _objects:
+        del _objects[object]
 
 
 class Component:


### PR DESCRIPTION
This fixes issues #89 and #90 (bundled as both fixes are needed for each other) by importing delete_object into the toplevel namespace as with create_object, and fixing delete_object so it both successfully takes an Object, and also is able to take an ID as per the old behavior.