### PR TITLE
Fix #99 - change window id property of SaveAs to use signed value

### DIFF
--- a/riscos_toolbox/objects/saveas.py
+++ b/riscos_toolbox/objects/saveas.py
@@ -38,7 +38,7 @@ class SaveAs(Object):
 
     @property
     def window_id(self):
-        return self._miscop_get_unsigned(SaveAs.GetWindowId)
+        return self._miscop_get_signed(SaveAs.GetWindowId)
 
     @property
     def title(self):


### PR DESCRIPTION
This fixes issue #99 by changing the window_id property of SaveAs to use a signed value, as elsewhere in the library (see issues #75 and #78)