### PR TITLE
Fixes #97 by adding a get_flag method to the ToolboxEvent class

### DIFF
--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -93,6 +93,10 @@ class ToolboxEvent(Event, ctypes.Structure):
         ("event_code", ctypes.c_uint32),
         ("flags", ctypes.c_uint32)
     ]
+    
+    def get_flag(self, flag):
+        """ Gets one event flag."""
+        return self.flags & flag != 0
 
 
 class AboutToBeShownEvent(ToolboxEvent):


### PR DESCRIPTION
Fixes issue #97 - the flag properties of RadioButtonStateChangedEvent try to call a nonexistent get_flag method; rather than fix it within these property methods, this adds a get_flag method to the parent class as it will likely be useful elsewhere.