### PR TITLE
Correct redraw loop to use Wimp_GetRectangle

### DIFF
--- a/riscos_toolbox/mixins/window.py
+++ b/riscos_toolbox/mixins/window.py
@@ -27,7 +27,7 @@ class UserRedrawMixin:
 
             self.redraw_window(rd.visible, rd.scroll, rd.redraw, offset)
 
-            more = swi.swi("Wimp_RedrawWindow", ".I;I", ctypes.addressof(rd))
+            more = swi.swi("Wimp_GetRectangle", ".I;I", ctypes.addressof(rd))
 
     def redraw_window(self, visible, scroll, redraw, offset):
         pass


### PR DESCRIPTION
By calling Wimp_RedrawWindow again, the redraw loop was never completed properly, and Toolbox gadgets in the window were largely not redrawn in my example.