### PR TITLE
User message sending function improvements

### DIFF
--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -112,7 +112,7 @@ class AboutToBeShownEvent(ToolboxEvent):
         ("_scroll", Point),
         ("_behind", ctypes.c_int32),
         ("_window_flags", ctypes.c_uint32),
-        ("+parent_window_handle", ctypes.c_int32),
+        ("_parent_window_handle", ctypes.c_int32),
         ("_alignment_flags", ctypes.c_uint32)]
 
     def get_if(self, value, show_type):

--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -16,14 +16,14 @@ from ._types import BBox, Point
 # is used for both wimp messages and wimp events.
 #
 # To handle a toolbox event, the @toolbox_handler decorator is used on a member of
-# a class derived from riscos_toolbox.  event.EvebtDispatcher, such as .Object
+# a class derived from riscos_toolbox.  event.EventDispatcher, such as .Object
 # or .Application. The decorator can be used to match all components (with
 # @ToolboxEvent(event)...), one component (@toolbox_handler(event, component)...)
 # or a list of components (@toolbox_handler(event, [comp1,comp2]...)
 #
 # 'event' can either be a class name derived from Event, or an integer number. In
 # the first case, the handler will be called with an instance of the class, created
-# using it's from_block method. In the second, the handler will be called with the
+# using its from_block method. In the second, the handler will be called with the
 # raw data from the wimp poll block.
 #
 # When a toolbox event is received, the library will try each of the self,
@@ -32,13 +32,13 @@ from ._types import BBox, Point
 #
 # For each level; if a a handler exists for the component id (from id_block.
 # self.component) it will be called, or if no such handler exists, but there
-# is an "all components" handler that will  be called.
+# is an "all components" handler that will be called.
 #
-# This means a "all components" handler from a more specific object will
+# This means an "all components" handler from a more specific object will
 # take precedence over a more specific one from a less specific object.
 #
-# If one is found and it DOESN'T return False, the process with end. If the
-# handler is not found, or returns  False, the next one will be tried. Not
+# If one is found and it DOESN'T return False, the process will end. If the
+# handler is not found, or returns False, the next one will be tried. Not
 # returning anything from the handler will therefore cause further handlers not
 # to be tried.
 #
@@ -55,11 +55,11 @@ from ._types import BBox, Point
 # ---------------------------
 # Wimp messages have an extra 'send' function which can be used to send them
 # to another task. This optionally has a callback function to call when a reply
-# is recieved (a message where the 'your ref' of the a message to matches the
+# is received (a message where the 'your ref' of the message matches my_ref of the
 # one sent). On a reply the callback function will be called with the message.
-# If the callback function  doesn't return False, then no further processing will
+# If the callback function doesn't return False, then no further processing will
 # take place on the message. If it DOES return False, it will be offered to the
-# handlers in the usual way. If no reply is recieved the callback will be called
+# handlers in the usual way. If no reply is received the callback will be called
 # with None. In either case, the callback will be removed from the list of callbacks.
 
 
@@ -177,7 +177,7 @@ class UserMessage(Event, ctypes.Structure):
     def send(self, task=None, window=None, iconbar=None,
              recorded=False, size=None,
              reply_callback=None):
-        """Sendds the message to a task, window or iconbar icon."""
+        """Sends the message to a task, window or iconbar icon."""
         self.your_ref = 0
         if task:
             handle, icon = task, 0
@@ -188,14 +188,14 @@ class UserMessage(Event, ctypes.Structure):
         else:
             handle, icon = 0, 0  # Broadcast
 
-        self._send(Wimp.UserMessageRecorded if recorded else Wimp.UserMessage,
-                   handle, icon, reply_callback)
+        return self._send(Wimp.UserMessageRecorded if recorded else Wimp.UserMessage,
+                   handle, icon, size, reply_callback)
 
     def reply(self, reply, recorded=False, size=None,
               reply_callback=None, reply_messages=None):
         """Reply to this message with the one given in reply"""
         reply.your_ref = self.my_ref
-        reply._send(Wimp.UserMessageRecorded if recorded else Wimp.UserMessage,
+        return reply._send(Wimp.UserMessageRecorded if recorded else Wimp.UserMessage,
                     self.sender, None, size, reply_callback)
 
     def acknowledge(self):
@@ -206,7 +206,7 @@ class UserMessage(Event, ctypes.Structure):
                        self.sender, 0)
 
     def _send(self, reason, target, icon, size, reply_callback):
-        self.size = size or ctypes.sizeof(self)
+        self.size = size or self.size or ctypes.sizeof(self)
         self.code = self.__class__.event_id
         handle = swi.swi('Wimp_SendMessage', 'IIii;..i',
                          reason, ctypes.addressof(self),


### PR DESCRIPTION
Added missing size parameter to call of _send() from send().

Make send() and reply() return the task handle returned by _send.

In _send(), take the size first from the size parameter if given, but allow it to come from self.size if it has been set, before falling back on the size of the message type. This allows message classes to offer setter functions for complex message entries which set the size of the message automatically.

Fix typos in comments.
