### PR TITLE
Pass the MessageInfo object through to reply callbacks

### DIFF
--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -388,18 +388,19 @@ def reply_handler(message_s):
         @wraps((handler, _message_map))
         def wrapper(self, data, *args):
             message = None
-            code = None
+            info = None
             if data is not None:
+                info = data[0]
                 message = ctypes.cast(
-                    data, ctypes.POINTER(UserMessage)
+                    data[1], ctypes.POINTER(UserMessage)
                 ).contents
 
                 code = message.code
                 if code in _message_map:
                     message = ctypes.cast(
-                        data, ctypes.POINTER(_message_map[code])
+                        data[1], ctypes.POINTER(_message_map[code])
                     ).contents
-            return handler(self, code, message, *args)
+            return handler(self, info, message, *args)
         return wrapper
     return decorator
 
@@ -429,13 +430,13 @@ def toolbox_dispatch(event_code, application, id_block, poll_block):
 
 def message_dispatch(code, application, id_block, poll_block):
     if code.your_ref in _reply_callbacks:
-        r = _reply_callbacks[code.your_ref](poll_block)
+        r = _reply_callbacks[code.your_ref]((code, poll_block))
         del _reply_callbacks[code.your_ref]
         if r is not False:
             return
 
     if code.reason == Wimp.UserMessageAcknowledge and code.my_ref in _reply_callbacks:
-        r = _reply_callbacks[code.my_ref](poll_block)
+        r = _reply_callbacks[code.my_ref]((code, poll_block))
         del _reply_callbacks[code.my_ref]
         if r is not False:
             return


### PR DESCRIPTION
The reply callback takes a single parameter, so that a callback may be implemented as a lambda, and so this was the poll block for the whole message, from which the message code could be extracted. But this means that the "code" passed to the reply handler is just the numeric code, whereas a message handler gets a MessageInfo object which allows it also to access the Wimp reason code.

Occasionally user messages are expected to receive a reply which uses the same message code. Being able to check if the reason code is 17/18 or 19 will help determine if it is a genuine reply or our own recorded delivery being bounced.

I chose the tuple to pass the two parameters as a single item, as it seemed the simplest solution: feel free to pick a different way of doing it.