### PR TITLE
Add function to read task's sprite area

### DIFF
--- a/riscos_toolbox/__init__.py
+++ b/riscos_toolbox/__init__.py
@@ -36,6 +36,13 @@ def task_handle():
         return None
 
 
+def sprite_area():
+    try:
+        return swi.swi('Toolbox_GetSysInfo', "I;i", 4)
+    except Exception:
+        return None
+
+
 def throwback_traceback(e):
     try:
         type, value, tb = sys.exc_info()


### PR DESCRIPTION
Although the sprites will automatically be used in any window gadgets defined in the resources file, the task's Sprite file may also define things like pointer shapes which the developer will need to be able to access via the sprite area pointer.