### PR TITLE
Ensure MessageTrans_Lookup R4-R7 set to zero if no arguments provided

### DIFF
--- a/riscos_toolbox/__init__.py
+++ b/riscos_toolbox/__init__.py
@@ -97,7 +97,8 @@ def initialise(appdir):
 def msgtrans_lookup(token, *args, bufsize=256):
     args = args[:4]
     buffer = swi.block((bufsize + 3) // 4)
-    swi.swi('MessageTrans_Lookup', 'bsbi' + ('s' * len(args)),
+    swi.swi('MessageTrans_Lookup',
+            'bsbi' + ('s' * len(args)) + ('0' * (4-len(args))),
             _msgtrans_block, token, buffer, bufsize, *args)
     return buffer.ctrlstring()
 


### PR DESCRIPTION
If the message in the Messages file has more parameters than are provided as arguments to the msgtrans_lookup call, then the values of the registers R4 to R7 would be used, despite being unpredictable in value. This change guards against unintended revealing of random memory contents.