### PR TITLE
Add reply callback timeouts

### DIFF
--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -388,18 +388,19 @@ def reply_handler(message_s):
         @wraps((handler, _message_map))
         def wrapper(self, data, *args):
             message = None
-            code = None
+            info = None
             if data is not None:
+                info = data[0]
                 message = ctypes.cast(
-                    data, ctypes.POINTER(UserMessage)
+                    data[1], ctypes.POINTER(UserMessage)
                 ).contents
 
                 code = message.code
                 if code in _message_map:
                     message = ctypes.cast(
-                        data, ctypes.POINTER(_message_map[code])
+                        data[1], ctypes.POINTER(_message_map[code])
                     ).contents
-            return handler(self, code, message, *args)
+            return handler(self, info, message, *args)
         return wrapper
     return decorator
 
@@ -429,13 +430,13 @@ def toolbox_dispatch(event_code, application, id_block, poll_block):
 
 def message_dispatch(code, application, id_block, poll_block):
     if code.your_ref in _reply_callbacks:
-        r = _reply_callbacks[code.your_ref](poll_block)
+        r = _reply_callbacks[code.your_ref]((code, poll_block))
         del _reply_callbacks[code.your_ref]
         if r is not False:
             return
 
     if code.reason == Wimp.UserMessageAcknowledge and code.my_ref in _reply_callbacks:
-        r = _reply_callbacks[code.my_ref](poll_block)
+        r = _reply_callbacks[code.my_ref]((code, poll_block))
         del _reply_callbacks[code.my_ref]
         if r is not False:
             return


### PR DESCRIPTION
Note: builds on #107 

This change allows the developer to define how many seconds should pass before the reply callback should be called in the case of no reply and no bounce being received. When awaiting a reply to a recorded message, it is not always appropriate to alert the callback as soon as we get a null Wimp poll, because it is possible that the recipient of the message has acknowledged our message (to prevent a bounce) but is doing some background work before replying.

The timeout defaults to 0 seconds, to match the previous behaviour. It can be set to an appropriate number of seconds (or fractions of seconds) according to what is reasonable for the potential background processing. Or the reply_timeout can be set to None to wait indefinitely. In this situation it is possible that the reply_callback object will never be called or cleaned up.