### PR TITLE
Application level handler support

### DIFF
--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -388,18 +388,19 @@ def reply_handler(message_s):
         @wraps((handler, _message_map))
         def wrapper(self, data, *args):
             message = None
-            code = None
+            info = None
             if data is not None:
+                info = data[0]
                 message = ctypes.cast(
-                    data, ctypes.POINTER(UserMessage)
+                    data[1], ctypes.POINTER(UserMessage)
                 ).contents
 
                 code = message.code
                 if code in _message_map:
                     message = ctypes.cast(
-                        data, ctypes.POINTER(_message_map[code])
+                        data[1], ctypes.POINTER(_message_map[code])
                     ).contents
-            return handler(self, code, message, *args)
+            return handler(self, info, message, *args)
         return wrapper
     return decorator
 
@@ -429,13 +430,13 @@ def toolbox_dispatch(event_code, application, id_block, poll_block):
 
 def message_dispatch(code, application, id_block, poll_block):
     if code.your_ref in _reply_callbacks:
-        r = _reply_callbacks[code.your_ref](poll_block)
+        r = _reply_callbacks[code.your_ref]((code, poll_block))
         del _reply_callbacks[code.your_ref]
         if r is not False:
             return
 
     if code.reason == Wimp.UserMessageAcknowledge and code.my_ref in _reply_callbacks:
-        r = _reply_callbacks[code.my_ref](poll_block)
+        r = _reply_callbacks[code.my_ref]((code, poll_block))
         del _reply_callbacks[code.my_ref]
         if r is not False:
             return


### PR DESCRIPTION
Branched from #114 but could be applied separately.

I may just be doing things wrong, but as the system is currently designed, if you want message handlers or wimp handlers to be called without being identified with a toolbox object, you have to include them in the main class of your application. That's because the dispatcher uses the id_block from Wimp_Poll to identify which toolbox object (or parent or ancestor) is referred to, and calls those handlers, falling back on handlers registered on the application itself. If you want a null poll handler, or a message handler, or any other handler that is not associated with the identifier of a toolbox object, these have to be declared in the application.

This change allows such handlers to be declared in other classes, yet be called at the application level alongside other application handlers. The code does this for any handler declared in a class which inherits neither from Application nor from Object. I am not sure if this is sufficient: it may be that mixins would pose difficulties. But it makes it easier to arrange the code of a bigger application in a logical way.