### PR TITLE
Allow your_ref in send method

### DIFF
--- a/riscos_toolbox/events.py
+++ b/riscos_toolbox/events.py
@@ -388,18 +388,19 @@ def reply_handler(message_s):
         @wraps((handler, _message_map))
         def wrapper(self, data, *args):
             message = None
-            code = None
+            info = None
             if data is not None:
+                info = data[0]
                 message = ctypes.cast(
-                    data, ctypes.POINTER(UserMessage)
+                    data[1], ctypes.POINTER(UserMessage)
                 ).contents
 
                 code = message.code
                 if code in _message_map:
                     message = ctypes.cast(
-                        data, ctypes.POINTER(_message_map[code])
+                        data[1], ctypes.POINTER(_message_map[code])
                     ).contents
-            return handler(self, code, message, *args)
+            return handler(self, info, message, *args)
         return wrapper
     return decorator
 
@@ -429,13 +430,13 @@ def toolbox_dispatch(event_code, application, id_block, poll_block):
 
 def message_dispatch(code, application, id_block, poll_block):
     if code.your_ref in _reply_callbacks:
-        r = _reply_callbacks[code.your_ref](poll_block)
+        r = _reply_callbacks[code.your_ref]((code, poll_block))
         del _reply_callbacks[code.your_ref]
         if r is not False:
             return
 
     if code.reason == Wimp.UserMessageAcknowledge and code.my_ref in _reply_callbacks:
-        r = _reply_callbacks[code.my_ref](poll_block)
+        r = _reply_callbacks[code.my_ref]((code, poll_block))
         del _reply_callbacks[code.my_ref]
         if r is not False:
             return


### PR DESCRIPTION
Builds on #116.

The send() method in UserMessage insists on setting your_ref to zero, and the idea is you use reply() to respond to an incoming message which quotes the incoming message's my_ref as the your_ref value of the message to transmit. There are some protocols (e.g. [Message_Dragging](https://chrisacorns.computinghistory.org.uk/docs/Acorn/AN/241.pdf) and GeoData messages like [Message_GeoData_TransmitData](https://sinenomine.co.uk/software/riscosm/GeoDataMessages.pdf)) where the same your_ref might be used several times as a single incoming message may prompt multiple replies. In these cases it is useful to be able to store the my_ref and apply it manually. This change modifies send() in a backwards-compatible manner.